### PR TITLE
added darkreader lock :)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import "./globals.css";
 import { Grid } from "@/components/ui/grid";
+import Head from 'next/head'
 
 export const metadata: Metadata = {
   alternates: { canonical: "https://webhook.uncoverit.org" },
@@ -94,6 +95,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <Head><meta name="darkreader-lock" /></Head>
       <body>
         <ThemeProvider attribute="class" disableTransitionOnChange>
           <div


### PR DESCRIPTION
## Summary by Sourcery

Lock Dark Reader in the root layout by injecting a meta tag to prevent Dark Reader from overriding the site’s theme

Enhancements:
- Import the Next.js Head component in the root layout
- Add a `<meta name="darkreader-lock" />` tag inside the HTML head