### PR TITLE
Enable Send and Start Spam when only an embed, poll, or file is set

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1380,7 +1380,14 @@ export default function WebhookTool() {
                     ) : (
                       <Button
                         onClick={startSpam}
-                        disabled={loading || !webhookUrl || !content}
+                        disabled={
+                          loading ||
+                          !webhookUrl ||
+                          (!content &&
+                            !useEmbed &&
+                            !usePoll &&
+                            files.length === 0)
+                        }
                       >
                         <Play className="size-4" />
                         Start Spam
@@ -1389,7 +1396,14 @@ export default function WebhookTool() {
                   ) : (
                     <Button
                       onClick={sendWebhook}
-                      disabled={loading || !webhookUrl || !content}
+                      disabled={
+                        loading ||
+                        !webhookUrl ||
+                        (!content &&
+                          !useEmbed &&
+                          !usePoll &&
+                          files.length === 0)
+                      }
                     >
                       <Send className="size-4" />
                       {loading ? "Sending..." : "Send Webhook"}


### PR DESCRIPTION
Closes #2622.

## Summary

The disabled predicate on the Send Webhook and Start Spam buttons only checked `content`, so embed-only, poll-only, or attachment-only sends were blocked from the UI even though Discord accepts them and `sendWebhook` already builds the payload conditionally.

This widens the check to also allow the button when an embed, a poll, or at least one attached file is present.

## Changes

`src/app/page.tsx`: both buttons now use

```ts
disabled={
  loading ||
  !webhookUrl ||
  (!content && !useEmbed && !usePoll && files.length === 0)
}
```

## Test plan

- [ ] Paste a webhook URL, leave content empty, turn on "Include Embed", fill the title or description: Send Webhook is enabled and the request goes through.
- [ ] Same with Poll only.
- [ ] Same with one attached file only.
- [ ] With everything empty (no content, no embed, no poll, no files): Send stays disabled.
- [ ] Same four cases for Start Spam.