### PR TITLE
Respect Discord 429 retry_after in the spam loop

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -493,6 +493,18 @@ export default function WebhookTool() {
           });
 
           if (!response.ok) {
+            if (response.status === 429) {
+              const data = await response
+                .json()
+                .catch(() => ({} as { retry_after?: number }));
+              const headerRetry = response.headers.get("retry-after");
+              const wait = Math.max(
+                Number(data?.retry_after ?? headerRetry ?? 1),
+                0.1,
+              );
+              await new Promise((r) => setTimeout(r, wait * 1000));
+              continue;
+            }
             const error = await response.json();
             throw new Error(error.message);
           }


### PR DESCRIPTION
Closes #2623.

## Summary

When the spam loop got rate limited, it caught the 429 in the existing `try`/`catch`, decided not to stop, and immediately re-entered the loop. There was no `await` of any timer and no read of `retry_after`, so requests fired back to back at full speed once Discord started rate limiting, which can escalate to Cloudflare-level blocks against the user's IP.

This handles 429 explicitly: parse `retry_after` from the JSON body (falling back to the `Retry-After` header, then to 1s), `await` that delay, and `continue` the loop. All other non-OK responses keep the previous behaviour.

## Changes

`src/app/page.tsx`, inside the spam `while` loop, immediately after `if (!response.ok)`:

```ts
if (response.status === 429) {
  const data = await response
    .json()
    .catch(() => ({} as { retry_after?: number }));
  const headerRetry = response.headers.get("retry-after");
  const wait = Math.max(
    Number(data?.retry_after ?? headerRetry ?? 1),
    0.1,
  );
  await new Promise((r) => setTimeout(r, wait * 1000));
  continue;
}
```

## Test plan

- [ ] Start spam against a real webhook. After Discord starts returning 429, observe in DevTools Network that subsequent requests are spaced by roughly the `retry_after` value, not back to back.
- [ ] Spam still stops cleanly via the Stop Spam button.
- [ ] A non-429 error (for example, an invalid webhook URL) still surfaces a toast and stops the loop, same as before.