### PR TITLE
Pass width and height to the history avatar Image

### DIFF
--- a/src/components/webhook-history.tsx
+++ b/src/components/webhook-history.tsx
@@ -187,6 +187,8 @@ export function WebhookHistory({ history }: WebhookHistoryProps) {
                               <Image
                                 src={item.payload.avatar_url}
                                 alt="Avatar"
+                                width={24}
+                                height={24}
                                 className="w-full h-full object-cover"
                               />
                             </div>


### PR DESCRIPTION
Closes #2626.

## Summary

`next/image` requires `width`, `height`, or `fill`. The avatar render in the History tab passed none of those, so opening the tab for any saved send that had an `avatar_url` crashed the tab.

The container is `w-6 h-6`, so set the matching backing size.

## Changes

`src/components/webhook-history.tsx`:

```tsx
<Image
  src={item.payload.avatar_url}
  alt="Avatar"
  width={24}
  height={24}
  className="w-full h-full object-cover"
/>
```

## Test plan

- [ ] Reproduce with the snippet from #2626 (set a `webhookHistory` entry with `avatar_url` in localStorage and reload).
- [ ] Open the History tab. The entry renders with the avatar instead of throwing.
- [ ] Entries without `avatar_url` still render the gray placeholder circle.