### PR TITLE
Confirm before deleting the webhook on Discord

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,6 +54,16 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import github from "@/../public/github.svg";
 import discord from "@/../public/discord.svg";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
 
 import {
   DropdownMenu,
@@ -658,47 +668,79 @@ export default function WebhookTool() {
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <Button
-                          aria-label="Delete Webhook"
-                          variant="destructive"
-                          size="icon"
-                          {...(webhookUrl ? {} : { disabled: true })}
-                          onClick={async () => {
-                            if (!webhookUrl) return;
-                            if (
-                              !window.confirm(
-                                "Permanently delete this webhook on Discord? This cannot be undone.",
-                              )
-                            ) {
-                              return;
-                            }
-                            try {
-                              const response = await fetch(webhookUrl, {
-                                method: "DELETE",
-                              });
-                              if (response.ok) {
-                                setWebhookUrl("");
-                                toast.success("Webhook deleted", {
-                                  description:
-                                    "The webhook has been deleted from Discord.",
-                                });
-                              } else {
-                                toast.error("Failed to delete webhook", {
-                                  description: `Error: ${response.status} ${response.statusText}`,
-                                });
-                              }
-                            } catch (error) {
-                              toast.error("Error deleting webhook", {
-                                description:
-                                  error instanceof Error
-                                    ? error.message
-                                    : "Unknown error occurred",
-                              });
-                            }
-                          }}
-                        >
-                          <Trash2 />
-                        </Button>
+                        <Dialog>
+                          <DialogTrigger>
+                            <Button
+                              aria-label="Delete Webhook"
+                              variant="destructive"
+                              size="icon"
+                              {...(webhookUrl ? {} : { disabled: true })}
+                            >
+                              <Trash2 />
+                            </Button>
+                          </DialogTrigger>{" "}
+                          <DialogContent>
+                            <DialogHeader>
+                              <DialogTitle>
+                                Are you absolutely sure?
+                              </DialogTitle>
+                              <DialogDescription>
+                                This action cannot be undone. This will
+                                permanently delete your account and remove your
+                                data from our servers.
+                              </DialogDescription>
+                            </DialogHeader>
+                            <DialogFooter>
+                              <DialogClose asChild>
+                                <Button
+                                  type="button"
+                                  size={"sm"}
+                                  className="rounded-lg"
+                                >
+                                  Close
+                                </Button>
+                              </DialogClose>
+                              <DialogClose asChild>
+                                <Button
+                                  variant={"destructive"}
+                                  size={"sm"}
+                                  className="rounded-lg"
+                                  onClick={async () => {
+                                    if (!webhookUrl) return;
+                                    try {
+                                      const response = await fetch(webhookUrl, {
+                                        method: "DELETE",
+                                      });
+                                      if (response.ok) {
+                                        setWebhookUrl("");
+                                        toast.success("Webhook deleted", {
+                                          description:
+                                            "The webhook has been deleted from Discord.",
+                                        });
+                                      } else {
+                                        toast.error(
+                                          "Failed to delete webhook",
+                                          {
+                                            description: `Error: ${response.status} ${response.statusText}`,
+                                          },
+                                        );
+                                      }
+                                    } catch (error) {
+                                      toast.error("Error deleting webhook", {
+                                        description:
+                                          error instanceof Error
+                                            ? error.message
+                                            : "Unknown error occurred",
+                                      });
+                                    }
+                                  }}
+                                >
+                                  Delete
+                                </Button>
+                              </DialogClose>
+                            </DialogFooter>
+                          </DialogContent>
+                        </Dialog>
                       </TooltipTrigger>
                       <TooltipContent>
                         <p>Delete Webhook</p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -665,6 +665,13 @@ export default function WebhookTool() {
                           {...(webhookUrl ? {} : { disabled: true })}
                           onClick={async () => {
                             if (!webhookUrl) return;
+                            if (
+                              !window.confirm(
+                                "Permanently delete this webhook on Discord? This cannot be undone.",
+                              )
+                            ) {
+                              return;
+                            }
                             try {
                               const response = await fetch(webhookUrl, {
                                 method: "DELETE",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}


### PR DESCRIPTION
Closes #2627.

## Summary

The trash icon next to the webhook URL field fires `DELETE` on Discord on a single click. Two other trash icons in the same UI (Saved list, History list) only delete local state, so it is easy to misread this one. Add a `window.confirm` so a misclick does not silently destroy the webhook.

## Changes

`src/app/page.tsx`, in the URL-field trash button click handler:

```ts
if (!webhookUrl) return;
if (
  !window.confirm(
    "Permanently delete this webhook on Discord? This cannot be undone.",
  )
) {
  return;
}
```

## Test plan

- [ ] Paste a webhook URL, click the red trash icon next to it, dismiss the confirm dialog. The webhook is not deleted, no toast appears, the URL field still shows the URL.
- [ ] Same but accept the confirm. The webhook is deleted, the field clears, and the existing "Webhook deleted" toast appears.