### PR TITLE
Update history list in place instead of reloading the page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1639,7 +1639,7 @@ export default function WebhookTool() {
         </TabsContent>
 
         <TabsContent value="history" className="space-y-4 mt-4">
-          <WebhookHistory history={history} />
+          <WebhookHistory history={history} setHistory={setHistory} />
         </TabsContent>
       </Tabs>
       <footer className="mt-8 text-right flex justify-end gap-2">

--- a/src/components/webhook-history.tsx
+++ b/src/components/webhook-history.tsx
@@ -41,9 +41,10 @@ interface WebhookHistoryItem {
 
 interface WebhookHistoryProps {
   history: WebhookHistoryItem[];
+  setHistory: (history: WebhookHistoryItem[]) => void;
 }
 
-export function WebhookHistory({ history }: WebhookHistoryProps) {
+export function WebhookHistory({ history, setHistory }: WebhookHistoryProps) {
   const [loading, setLoading] = useState<Record<number, boolean>>({});
 
   const formatDate = (dateString: string) => {
@@ -101,14 +102,13 @@ export function WebhookHistory({ history }: WebhookHistoryProps) {
 
   const clearHistory = () => {
     localStorage.removeItem("webhookHistory");
-    window.location.reload();
+    setHistory([]);
   };
 
   const deleteHistoryItem = (index: number) => {
-    const newHistory = [...history];
-    newHistory.splice(index, 1);
+    const newHistory = history.filter((_, i) => i !== index);
     localStorage.setItem("webhookHistory", JSON.stringify(newHistory));
-    window.location.reload();
+    setHistory(newHistory);
   };
 
   return (


### PR DESCRIPTION
Closes #2628.

## Summary

`clearHistory` and `deleteHistoryItem` wrote to `localStorage` and then called `window.location.reload()` to refresh the visible list. Because the history list lives in the same SPA as the form, the reload also wiped whatever the user had typed into the Message tab (content, embeds, polls, attachments).

Lift `setHistory` from the parent and update state directly. No reload, no lost work.

## Changes

`src/app/page.tsx`: pass `setHistory` to `<WebhookHistory>`.

`src/components/webhook-history.tsx`:

- Add `setHistory` to `WebhookHistoryProps`.
- `clearHistory`: `localStorage.removeItem("webhookHistory"); setHistory([]);`
- `deleteHistoryItem`: rebuild via `filter`, write localStorage, `setHistory(newHistory)`.

## Test plan

- [ ] Type some content, fill an embed, attach a file in the Message tab.
- [ ] Switch to History, click "Clear History". Confirm the list empties.
- [ ] Switch back to Message: content, embed, and attachments are still there.
- [ ] Same flow with the per-entry trash icon: only that entry disappears, Message tab is untouched.