### PR TITLE
Tolerate corrupt savedWebhooks and webhookHistory in localStorage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -163,12 +163,20 @@ export default function WebhookTool() {
   useEffect(() => {
     const saved = localStorage.getItem("savedWebhooks");
     if (saved) {
-      setSavedWebhooks(JSON.parse(saved));
+      try {
+        setSavedWebhooks(JSON.parse(saved));
+      } catch {
+        localStorage.removeItem("savedWebhooks");
+      }
     }
 
     const historyData = localStorage.getItem("webhookHistory");
     if (historyData) {
-      setHistory(JSON.parse(historyData));
+      try {
+        setHistory(JSON.parse(historyData));
+      } catch {
+        localStorage.removeItem("webhookHistory");
+      }
     }
   }, []);
 


### PR DESCRIPTION
Closes #2629.

## Summary

The mount effect parsed `savedWebhooks` and `webhookHistory` from `localStorage` without a `try`/`catch`. A malformed value (browser extension, manual edit, partial write) threw and the page never finished its initial render.

Wrap each parse, and on failure drop the bad key so the app keeps loading with the default empty state.

## Changes

`src/app/page.tsx`, in the mount `useEffect`:

```ts
const saved = localStorage.getItem("savedWebhooks");
if (saved) {
  try {
    setSavedWebhooks(JSON.parse(saved));
  } catch {
    localStorage.removeItem("savedWebhooks");
  }
}

const historyData = localStorage.getItem("webhookHistory");
if (historyData) {
  try {
    setHistory(JSON.parse(historyData));
  } catch {
    localStorage.removeItem("webhookHistory");
  }
}
```

## Test plan

- [ ] In DevTools: `localStorage.setItem("webhookHistory", "not json")`, reload. App still renders, History tab shows the empty state.
- [ ] Same with `savedWebhooks`.
- [ ] With valid stored values, both tabs still load their data unchanged.