### PR TITLE
Scale color picker click coords to canvas backing size

### DIFF
--- a/src/components/color-picker.tsx
+++ b/src/components/color-picker.tsx
@@ -101,8 +101,16 @@ export function ColorPicker({ color, onChange }: ColorPickerProps) {
     if (!canvas) return;
 
     const rect = canvas.getBoundingClientRect();
-    const x = Math.min(Math.max(0, e.clientX - rect.left), canvas.width - 1);
-    const y = Math.min(Math.max(0, e.clientY - rect.top), canvas.height - 1);
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const x = Math.min(
+      Math.max(0, (e.clientX - rect.left) * scaleX),
+      canvas.width - 1,
+    );
+    const y = Math.min(
+      Math.max(0, (e.clientY - rect.top) * scaleY),
+      canvas.height - 1,
+    );
 
     const ctx = canvas.getContext("2d");
     if (!ctx) return;


### PR DESCRIPTION
Closes #2630.

## Summary

The color picker canvas has a fixed backing size (200x200) but it is rendered with `w-full h-full` inside a wider, shorter popover. The click handler used raw mouse coordinates relative to the CSS rect and clamped them to `0..199`, so the colour you sampled did not match the place you clicked. Anything past the visible 199-pixel mark always returned the right or bottom edge.

Scale the mouse position by `canvas.width / rect.width` and `canvas.height / rect.height` before reading `getImageData`.

## Changes

`src/components/color-picker.tsx`, in `handleCanvasClick`:

```ts
const rect = canvas.getBoundingClientRect();
const scaleX = canvas.width / rect.width;
const scaleY = canvas.height / rect.height;
const x = Math.min(
  Math.max(0, (e.clientX - rect.left) * scaleX),
  canvas.width - 1,
);
const y = Math.min(
  Math.max(0, (e.clientY - rect.top) * scaleY),
  canvas.height - 1,
);
```

## Test plan

- [ ] Open the color picker. Click a colour near the right edge of the gradient: the sampled colour matches what you see, not a strip of red.
- [ ] Click in the middle: sampled colour matches.
- [ ] Click in the top-left corner: white. Bottom-left corner: black.
- [ ] Resize the window so the popover is a different width: clicks still pick the right colour.